### PR TITLE
chore(deps): bundle dependency updates

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -14,9 +14,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -31,4 +31,4 @@ jobs:
         run: node ./check-images.js
 
       - name: Run build
-        run: for i in {1..5}; do npm run build && break || sleep 1; done
+        run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,20 +10,20 @@
 			"devDependencies": {
 				"@inlang/message-lint-rule-empty-pattern": "^1.4.8",
 				"@inlang/message-lint-rule-missing-translation": "^1.4.8",
-				"@inlang/paraglide-js": "2.7.1",
-				"@inlang/plugin-message-format": "^4.0.0",
+				"@inlang/paraglide-js": "2.8.0",
+				"@inlang/plugin-message-format": "^4.2.0",
 				"@sveltejs/adapter-auto": "^7.0.0",
 				"@sveltejs/adapter-static": "^3.0.10",
 				"@sveltejs/enhanced-img": "^0.9.2",
-				"@sveltejs/kit": "^2.49.2",
-				"@sveltejs/vite-plugin-svelte": "^6.2.1",
+				"@sveltejs/kit": "^2.49.4",
+				"@sveltejs/vite-plugin-svelte": "^6.2.4",
 				"@types/eslint": "^9.6.1",
-				"@typescript-eslint/eslint-plugin": "^8.51.0",
-				"@typescript-eslint/parser": "^8.51.0",
+				"@typescript-eslint/eslint-plugin": "^8.52.0",
+				"@typescript-eslint/parser": "^8.52.0",
 				"eslint": "^9.39.2",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-jsx-a11y": "^6.10.2",
-				"eslint-plugin-svelte": "^3.13.1",
+				"eslint-plugin-svelte": "^3.14.0",
 				"mdsvex": "^0.12.6",
 				"patch-package": "^8.0.1",
 				"prettier": "^3.7.4",
@@ -36,7 +36,7 @@
 				"svelte-sitemap": "^2.7.1",
 				"tslib": "^2.8.1",
 				"typescript": "^5.9.3",
-				"vite": "^7.3.0"
+				"vite": "^7.3.1"
 			}
 		},
 		"node_modules/@emnapi/runtime": {
@@ -493,9 +493,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-			"integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1288,14 +1288,14 @@
 			}
 		},
 		"node_modules/@inlang/paraglide-js": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@inlang/paraglide-js/-/paraglide-js-2.7.1.tgz",
-			"integrity": "sha512-wCpnS9iRTRYMilvWBjB0ndf8+moon+AXz23Uh4wbpQjWhRJyvCytkGFzm7jeqAGggK4v3oeuyjva91TDMS+qhw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@inlang/paraglide-js/-/paraglide-js-2.8.0.tgz",
+			"integrity": "sha512-ataaSmV53zz+tIr+KJLdC3tTB1uikS79hvtLlZk2ikbGRB/kcyQeg+lsqzjsXCAvy0/O28ucCRjxbHsTzOVQVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@inlang/recommend-sherlock": "0.2.1",
-				"@inlang/sdk": "2.4.10",
+				"@inlang/recommend-sherlock": "^0.2.1",
+				"@inlang/sdk": "2.6.0",
 				"commander": "11.1.0",
 				"consola": "3.4.0",
 				"json5": "2.2.3",
@@ -1317,9 +1317,9 @@
 			}
 		},
 		"node_modules/@inlang/plugin-message-format": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@inlang/plugin-message-format/-/plugin-message-format-4.0.0.tgz",
-			"integrity": "sha512-zNpLxLTt+bDd3JLXj1ONzo+Q6AOzz2MfcgGo8XB6/bweGhFIndK3GU/q0iU4o7VI4KS1+OHNLpKwFcrAifwERQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@inlang/plugin-message-format/-/plugin-message-format-4.2.0.tgz",
+			"integrity": "sha512-OIsrlC5VhRfKMCWIaVRtQvn1Iu58gNyuawwE7E/cQTZ3+ADAMVQWkMVw39pIOyaKIomavMvHgSECJLBISpt8mg==",
 			"dev": true,
 			"dependencies": {
 				"flat": "^6.0.1"
@@ -1350,9 +1350,9 @@
 			}
 		},
 		"node_modules/@inlang/sdk": {
-			"version": "2.4.10",
-			"resolved": "https://registry.npmjs.org/@inlang/sdk/-/sdk-2.4.10.tgz",
-			"integrity": "sha512-MLcYSb9ERwvyfxMsMXGjmAYfh6Bn/rkT58ffkibWxbFLiL3ejSdmLGP8Wl7118dMo6nj2PXTcEPzUw+2YPQ62Q==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@inlang/sdk/-/sdk-2.6.0.tgz",
+			"integrity": "sha512-f4iVHVXyzOi0CXlXSAT7XPrReLBaVXy/po/qrOPf2OHh+hUwyD1bDx2EYC5KgrZ16z3ylWfqWVuc7o4l7/tuUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1360,7 +1360,7 @@
 				"@sinclair/typebox": "^0.31.17",
 				"kysely": "^0.27.4",
 				"sqlite-wasm-kysely": "0.3.0",
-				"uuid": "^10.0.0"
+				"uuid": "^13.0.0"
 			},
 			"engines": {
 				"node": ">=18.0.0"
@@ -1444,6 +1444,20 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@lix-js/sdk/node_modules/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@lix-js/server-protocol-schema": {
@@ -1956,9 +1970,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.49.2",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.49.2.tgz",
-			"integrity": "sha512-Vp3zX/qlwerQmHMP6x0Ry1oY7eKKRcOWGc2P59srOp4zcqyn+etJyQpELgOi4+ZSUgteX8Y387NuwruLgGXLUQ==",
+			"version": "2.49.4",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.49.4.tgz",
+			"integrity": "sha512-JFtOqDoU0DI/+QSG8qnq5bKcehVb3tCHhOG4amsSYth5/KgO4EkJvi42xSAiyKmXAAULW1/Zdb6lkgGEgSxdZg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -1987,26 +2001,30 @@
 				"@opentelemetry/api": "^1.0.0",
 				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0",
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
+				"typescript": "^5.3.3",
 				"vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0"
 			},
 			"peerDependenciesMeta": {
 				"@opentelemetry/api": {
 					"optional": true
+				},
+				"typescript": {
+					"optional": true
 				}
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-6.2.1.tgz",
-			"integrity": "sha512-YZs/OSKOQAQCnJvM/P+F1URotNnYNeU3P2s4oIpzm1uFaqUEqRxUB0g5ejMjEb5Gjb9/PiBI5Ktrq4rUUF8UVQ==",
+			"version": "6.2.4",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-6.2.4.tgz",
+			"integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
-				"debug": "^4.4.1",
 				"deepmerge": "^4.3.1",
-				"magic-string": "^0.30.17",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.0",
 				"vitefu": "^1.1.1"
 			},
 			"engines": {
@@ -2095,20 +2113,20 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.51.0.tgz",
-			"integrity": "sha512-XtssGWJvypyM2ytBnSnKtHYOGT+4ZwTnBVl36TA4nRO2f4PRNGz5/1OszHzcZCvcBMh+qb7I06uoCmLTRdR9og==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.52.0.tgz",
+			"integrity": "sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.51.0",
-				"@typescript-eslint/type-utils": "8.51.0",
-				"@typescript-eslint/utils": "8.51.0",
-				"@typescript-eslint/visitor-keys": "8.51.0",
-				"ignore": "^7.0.0",
+				"@eslint-community/regexpp": "^4.12.2",
+				"@typescript-eslint/scope-manager": "8.52.0",
+				"@typescript-eslint/type-utils": "8.52.0",
+				"@typescript-eslint/utils": "8.52.0",
+				"@typescript-eslint/visitor-keys": "8.52.0",
+				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
-				"ts-api-utils": "^2.2.0"
+				"ts-api-utils": "^2.4.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2118,7 +2136,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.51.0",
+				"@typescript-eslint/parser": "^8.52.0",
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
@@ -2134,18 +2152,18 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.51.0.tgz",
-			"integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.52.0.tgz",
+			"integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.51.0",
-				"@typescript-eslint/types": "8.51.0",
-				"@typescript-eslint/typescript-estree": "8.51.0",
-				"@typescript-eslint/visitor-keys": "8.51.0",
-				"debug": "^4.3.4"
+				"@typescript-eslint/scope-manager": "8.52.0",
+				"@typescript-eslint/types": "8.52.0",
+				"@typescript-eslint/typescript-estree": "8.52.0",
+				"@typescript-eslint/visitor-keys": "8.52.0",
+				"debug": "^4.4.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2160,15 +2178,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.51.0.tgz",
-			"integrity": "sha512-Luv/GafO07Z7HpiI7qeEW5NW8HUtZI/fo/kE0YbtQEFpJRUuR0ajcWfCE5bnMvL7QQFrmT/odMe8QZww8X2nfQ==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.52.0.tgz",
+			"integrity": "sha512-xD0MfdSdEmeFa3OmVqonHi+Cciab96ls1UhIF/qX/O/gPu5KXD0bY9lu33jj04fjzrXHcuvjBcBC+D3SNSadaw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.51.0",
-				"@typescript-eslint/types": "^8.51.0",
-				"debug": "^4.3.4"
+				"@typescript-eslint/tsconfig-utils": "^8.52.0",
+				"@typescript-eslint/types": "^8.52.0",
+				"debug": "^4.4.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2182,14 +2200,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.51.0.tgz",
-			"integrity": "sha512-JhhJDVwsSx4hiOEQPeajGhCWgBMBwVkxC/Pet53EpBVs7zHHtayKefw1jtPaNRXpI9RA2uocdmpdfE7T+NrizA==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.52.0.tgz",
+			"integrity": "sha512-ixxqmmCcc1Nf8S0mS0TkJ/3LKcC8mruYJPOU6Ia2F/zUUR4pApW7LzrpU3JmtePbRUTes9bEqRc1Gg4iyRnDzA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.51.0",
-				"@typescript-eslint/visitor-keys": "8.51.0"
+				"@typescript-eslint/types": "8.52.0",
+				"@typescript-eslint/visitor-keys": "8.52.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2200,9 +2218,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.51.0.tgz",
-			"integrity": "sha512-Qi5bSy/vuHeWyir2C8u/uqGMIlIDu8fuiYWv48ZGlZ/k+PRPHtaAu7erpc7p5bzw2WNNSniuxoMSO4Ar6V9OXw==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.52.0.tgz",
+			"integrity": "sha512-jl+8fzr/SdzdxWJznq5nvoI7qn2tNYV/ZBAEcaFMVXf+K6jmXvAFrgo/+5rxgnL152f//pDEAYAhhBAZGrVfwg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2217,17 +2235,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.51.0.tgz",
-			"integrity": "sha512-0XVtYzxnobc9K0VU7wRWg1yiUrw4oQzexCG2V2IDxxCxhqBMSMbjB+6o91A+Uc0GWtgjCa3Y8bi7hwI0Tu4n5Q==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.52.0.tgz",
+			"integrity": "sha512-JD3wKBRWglYRQkAtsyGz1AewDu3mTc7NtRjR/ceTyGoPqmdS5oCdx/oZMWD5Zuqmo6/MpsYs0wp6axNt88/2EQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.51.0",
-				"@typescript-eslint/typescript-estree": "8.51.0",
-				"@typescript-eslint/utils": "8.51.0",
-				"debug": "^4.3.4",
-				"ts-api-utils": "^2.2.0"
+				"@typescript-eslint/types": "8.52.0",
+				"@typescript-eslint/typescript-estree": "8.52.0",
+				"@typescript-eslint/utils": "8.52.0",
+				"debug": "^4.4.3",
+				"ts-api-utils": "^2.4.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2242,9 +2260,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.51.0.tgz",
-			"integrity": "sha512-TizAvWYFM6sSscmEakjY3sPqGwxZRSywSsPEiuZF6d5GmGD9Gvlsv0f6N8FvAAA0CD06l3rIcWNbsN1e5F/9Ag==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.52.0.tgz",
+			"integrity": "sha512-LWQV1V4q9V4cT4H5JCIx3481iIFxH1UkVk+ZkGGAV1ZGcjGI9IoFOfg3O6ywz8QqCDEp7Inlg6kovMofsNRaGg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2256,21 +2274,21 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.51.0.tgz",
-			"integrity": "sha512-1qNjGqFRmlq0VW5iVlcyHBbCjPB7y6SxpBkrbhNWMy/65ZoncXCEPJxkRZL8McrseNH6lFhaxCIaX+vBuFnRng==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.52.0.tgz",
+			"integrity": "sha512-XP3LClsCc0FsTK5/frGjolyADTh3QmsLp6nKd476xNI9CsSsLnmn4f0jrzNoAulmxlmNIpeXuHYeEQv61Q6qeQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.51.0",
-				"@typescript-eslint/tsconfig-utils": "8.51.0",
-				"@typescript-eslint/types": "8.51.0",
-				"@typescript-eslint/visitor-keys": "8.51.0",
-				"debug": "^4.3.4",
-				"minimatch": "^9.0.4",
-				"semver": "^7.6.0",
+				"@typescript-eslint/project-service": "8.52.0",
+				"@typescript-eslint/tsconfig-utils": "8.52.0",
+				"@typescript-eslint/types": "8.52.0",
+				"@typescript-eslint/visitor-keys": "8.52.0",
+				"debug": "^4.4.3",
+				"minimatch": "^9.0.5",
+				"semver": "^7.7.3",
 				"tinyglobby": "^0.2.15",
-				"ts-api-utils": "^2.2.0"
+				"ts-api-utils": "^2.4.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2284,16 +2302,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.51.0.tgz",
-			"integrity": "sha512-11rZYxSe0zabiKaCP2QAwRf/dnmgFgvTmeDTtZvUvXG3UuAdg/GU02NExmmIXzz3vLGgMdtrIosI84jITQOxUA==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.52.0.tgz",
+			"integrity": "sha512-wYndVMWkweqHpEpwPhwqE2lnD2DxC6WVLupU/DOt/0/v+/+iQbbzO3jOHjmBMnhu0DgLULvOaU4h4pwHYi2oRQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.7.0",
-				"@typescript-eslint/scope-manager": "8.51.0",
-				"@typescript-eslint/types": "8.51.0",
-				"@typescript-eslint/typescript-estree": "8.51.0"
+				"@eslint-community/eslint-utils": "^4.9.1",
+				"@typescript-eslint/scope-manager": "8.52.0",
+				"@typescript-eslint/types": "8.52.0",
+				"@typescript-eslint/typescript-estree": "8.52.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2308,13 +2326,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.51.0.tgz",
-			"integrity": "sha512-mM/JRQOzhVN1ykejrvwnBRV3+7yTKK8tVANVN3o1O0t0v7o+jqdVu9crPy5Y9dov15TJk/FTIgoUGHrTOVL3Zg==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.52.0.tgz",
+			"integrity": "sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.51.0",
+				"@typescript-eslint/types": "8.52.0",
 				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
@@ -3442,9 +3460,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-svelte": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.13.1.tgz",
-			"integrity": "sha512-Ng+kV/qGS8P/isbNYVE3sJORtubB+yLEcYICMkUWNaDTb0SwZni/JhAYXh/Dz/q2eThUwWY0VMPZ//KYD1n3eQ==",
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.14.0.tgz",
+			"integrity": "sha512-Isw0GvaMm0yHxAj71edAdGFh28ufYs+6rk2KlbbZphnqZAzrH3Se3t12IFh2H9+1F/jlDhBBL4oiOJmLqmYX0g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5274,6 +5292,17 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/obug": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT"
+		},
 		"node_modules/open": {
 			"version": "7.4.2",
 			"resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
@@ -6607,9 +6636,9 @@
 			}
 		},
 		"node_modules/ts-api-utils": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.3.0.tgz",
-			"integrity": "sha512-6eg3Y9SF7SsAvGzRHQvvc1skDAhwI4YQ32ui1scxD1Ccr0G5qIIbUBT3pFTKX8kmWIQClHobtUdNuaBgwdfdWg==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+			"integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6885,9 +6914,9 @@
 			"license": "MIT"
 		},
 		"node_modules/uuid": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+			"integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/broofa",
@@ -6895,7 +6924,7 @@
 			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"node_modules/vfile": {
@@ -6965,9 +6994,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
-			"integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,

--- a/package.json
+++ b/package.json
@@ -15,20 +15,20 @@
 	"devDependencies": {
 		"@inlang/message-lint-rule-empty-pattern": "^1.4.8",
 		"@inlang/message-lint-rule-missing-translation": "^1.4.8",
-		"@inlang/paraglide-js": "2.7.1",
-		"@inlang/plugin-message-format": "^4.0.0",
+		"@inlang/paraglide-js": "2.8.0",
+		"@inlang/plugin-message-format": "^4.2.0",
 		"@sveltejs/adapter-auto": "^7.0.0",
 		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/enhanced-img": "^0.9.2",
-		"@sveltejs/kit": "^2.49.2",
-		"@sveltejs/vite-plugin-svelte": "^6.2.1",
+		"@sveltejs/kit": "^2.49.4",
+		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@types/eslint": "^9.6.1",
-		"@typescript-eslint/eslint-plugin": "^8.51.0",
-		"@typescript-eslint/parser": "^8.51.0",
+		"@typescript-eslint/eslint-plugin": "^8.52.0",
+		"@typescript-eslint/parser": "^8.52.0",
 		"eslint": "^9.39.2",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-jsx-a11y": "^6.10.2",
-		"eslint-plugin-svelte": "^3.13.1",
+		"eslint-plugin-svelte": "^3.14.0",
 		"mdsvex": "^0.12.6",
 		"patch-package": "^8.0.1",
 		"prettier": "^3.7.4",
@@ -41,7 +41,7 @@
 		"svelte-sitemap": "^2.7.1",
 		"tslib": "^2.8.1",
 		"typescript": "^5.9.3",
-		"vite": "^7.3.0"
+		"vite": "^7.3.1"
 	},
 	"type": "module"
 }


### PR DESCRIPTION
## Summary
- Bundles all pending dependabot PRs into a single update
- Removes build retry loop from CI (flakiness has been resolved)

### NPM packages updated:
- @inlang/paraglide-js: 2.7.1 → 2.8.0
- @inlang/plugin-message-format: 4.0.0 → 4.2.0
- @sveltejs/kit: 2.49.2 → 2.49.4
- @sveltejs/vite-plugin-svelte: 6.2.1 → 6.2.4
- @typescript-eslint/eslint-plugin: 8.51.0 → 8.52.0
- @typescript-eslint/parser: 8.51.0 → 8.52.0
- eslint-plugin-svelte: 3.13.1 → 3.14.0
- vite: 7.3.0 → 7.3.1

### GitHub Actions updated:
- actions/checkout: v4 → v6
- actions/setup-node: v4 → v6

Closes #1, #2, #3, #4, #5, #6, #7, #8, #9, #10